### PR TITLE
Add Env Flag to Turn Off Testing In Cases Where it Has to Connect to Redis

### DIFF
--- a/command.go
+++ b/command.go
@@ -61,10 +61,10 @@ func (cmd *Command) Send(conn *Conn) (err error) {
 		if err != nil {
 			conn.state = connStateNotConnected
 			conn.Unlock()
-                        conn.fail()
-                } else {
+			conn.fail()
+		} else {
 			conn.Unlock()
-                }
+		}
 	}()
 	if conn.RequestTimeout != 0 {
 		conn.tcpConn.SetWriteDeadline(time.Now().Add(conn.RequestTimeout))

--- a/command_test.go
+++ b/command_test.go
@@ -1,10 +1,25 @@
 package gore
 
 import (
+	"os"
 	"testing"
 )
 
+var (
+	shouldTest = false
+)
+
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
+
 func TestGetSetBasic(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -39,6 +54,10 @@ func TestGetSetBasic(t *testing.T) {
 }
 
 func TestValueConverting(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -106,6 +125,10 @@ func TestValueConverting(t *testing.T) {
 }
 
 func TestArrayValue(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -185,6 +208,10 @@ func TestArrayValue(t *testing.T) {
 }
 
 func TestCommandGoroutine(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)

--- a/doc.go
+++ b/doc.go
@@ -218,7 +218,7 @@ after that. To deal with this problem, gore provides conn.Auth() method:
 
   conn.Auth("secret password")
 
-This method should be called when the connection is initialized. By calling Auth(), when 
+This method should be called when the connection is initialized. By calling Auth(), when
 gore tries to reconnect, is will also attempt to send AUTH command to redis server right
 after the connection is made.
 

--- a/error.go
+++ b/error.go
@@ -6,19 +6,19 @@ import (
 
 var (
 	// ErrNotConnected is returned when attempt to send command when connection is down
-	ErrNotConnected       = errors.New("not connected")
+	ErrNotConnected = errors.New("not connected")
 	// ErrEmptyScript is returned when try to execute an empty script
-	ErrEmptyScript        = errors.New("empty script")
+	ErrEmptyScript = errors.New("empty script")
 	// ErrType is returned when convert between different reply types
-	ErrType               = errors.New("type error")
+	ErrType = errors.New("type error")
 	// ErrConvert is returned when convert between data types
-	ErrConvert            = errors.New("convert error")
+	ErrConvert = errors.New("convert error")
 	// ErrKeyChanged is returned when transaction fails because watched keys have been changed
-	ErrKeyChanged         = errors.New("key changed")
-	// ErrTransactionAborted is returned when tracsaction fails because of other reasons 
+	ErrKeyChanged = errors.New("key changed")
+	// ErrTransactionAborted is returned when tracsaction fails because of other reasons
 	ErrTransactionAborted = errors.New("transaction aborted")
 	// ErrNil is for nil reply
-	ErrNil                = errors.New("nil value")
+	ErrNil = errors.New("nil value")
 	// ErrAuth is returned when redis AUTH fail
 	ErrAuth = errors.New("authentication fail")
 	//ErrNoShard is returned when trying to connect with a cluster with no shard
@@ -26,7 +26,7 @@ var (
 	// ErrNoKey is returned when sending command with no key to the cluster
 	ErrNoKey = errors.New("no key")
 	// ErrWrite is returned when connection cannot be written
-	ErrWrite              = errors.New("write error")
+	ErrWrite = errors.New("write error")
 	// ErrRead is returned when connection cannot be read
-	ErrRead               = errors.New("read error")
+	ErrRead = errors.New("read error")
 )

--- a/pipeline.go
+++ b/pipeline.go
@@ -36,10 +36,10 @@ func (p *Pipeline) Run(conn *Conn) (r []*Reply, err error) {
 	}
 	conn.Lock()
 	defer func() {
-                conn.Unlock()
-                if err != nil {
-                        conn.fail()
-                }
+		conn.Unlock()
+		if err != nil {
+			conn.fail()
+		}
 	}()
 	if conn.RequestTimeout != 0 {
 		conn.tcpConn.SetWriteDeadline(time.Now().Add(conn.RequestTimeout * time.Duration(len(p.commands)/10+1)))

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,10 +1,21 @@
 package gore
 
 import (
+	"os"
 	"testing"
 )
 
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
+
 func TestPipeline(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -47,6 +58,10 @@ func TestPipeline(t *testing.T) {
 }
 
 func TestPipelineGoroutine(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,10 +1,21 @@
 package gore
 
 import (
+	"os"
 	"testing"
 )
 
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
+
 func TestPool(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -70,6 +81,10 @@ func TestPool(t *testing.T) {
 }
 
 func TestPoolClose(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+	
 	pool := &Pool{
 		InitialConn: 20,
 		MaximumConn: 20,
@@ -85,7 +100,7 @@ func TestPoolClose(t *testing.T) {
 			defer func() {
 				c <- true
 			}()
-			conn, err := pool.Acquire()			
+			conn, err := pool.Acquire()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -95,7 +110,7 @@ func TestPoolClose(t *testing.T) {
 		}()
 	}
 	for i := 0; i < 20; i++ {
-		<- ready
+		<-ready
 	}
 	pool.Close()
 	for i := 0; i < 1000; i++ {

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -1,9 +1,16 @@
 package gore
 
 import (
+	"os"
 	"strconv"
 	"testing"
 )
+
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
 
 func TestPubsub(t *testing.T) {
 	tp := &testPubsub{t: t}
@@ -38,6 +45,11 @@ func (tp *testPubsub) publisher() {
 	defer func() {
 		tp.pubEnd <- true
 	}()
+
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -65,6 +77,11 @@ func (tp *testPubsub) subscriber() {
 	defer func() {
 		tp.subEnd <- true
 	}()
+
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)

--- a/script_test.go
+++ b/script_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
+
 var scriptSet = `
 return redis.call('SET', KEYS[1], ARGV[1])
 `
@@ -19,6 +25,10 @@ return redis.call('ZRANGE', KEYS[1], 0, -1)
 `
 
 func TestScript(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -73,6 +83,11 @@ func TestScriptMap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)

--- a/sharding_test.go
+++ b/sharding_test.go
@@ -1,10 +1,21 @@
 package gore
 
 import (
+	"os"
 	"testing"
 )
 
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
+
 func TestSharding(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	c := NewCluster()
 	c.AddShard("127.0.0.1:6379", "127.0.0.1:6380")
 	err := c.Dial()

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,10 +1,21 @@
 package gore
 
 import (
+	"os"
 	"testing"
 )
 
+func init() {
+	if os.Getenv("TEST_REDIS_CLIENT") != "" {
+		shouldTest = true
+	}
+}
+
 func TestTransaction(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	conn, err := Dial("localhost:6379")
 	if err != nil {
 		t.Fatal(err)
@@ -45,6 +56,10 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestTransactionGoroutine(t *testing.T) {
+	if !shouldTest {
+		return
+	}
+
 	c := make(chan bool, 20)
 
 	for i := 0; i < 50; i++ {


### PR DESCRIPTION
Created a flag that will be evaluated during tests.  If the flag has any value present the tests will run as is.  However it will not if it is not there.  This is important as many build systems etc are dependent on the tests passing.  In this case it may not be practical to have a running Redis instance present on the service doing the build.
